### PR TITLE
Update config.go

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 type ClusterCredentials struct {
@@ -82,6 +83,8 @@ func Parse() (*config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	c.ServiceName = strings.Replace(c.ServiceName, "_", "-", -1)
 
 	clusterCredentials := &ClusterCredentials{}
 	err = envconfig.Process("", clusterCredentials)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,6 +56,13 @@ var _ = Describe("Config", func() {
 			Expect(c.ClusterCredentials.Token).To(Equal("my-token"))
 		})
 
+		It("parses config from environment with underscore in service name", func() {
+			os.Setenv("SERVICE_NAME", "foo_bar")
+			c, err := Parse()
+			Expect(err).To(BeNil())
+			Expect(c.ServiceName).To(Equal("foo-bar"))
+		})
+
 		It("parses cluster credentials", func() {
 			c, err := Parse()
 			Expect(err).To(BeNil())


### PR DESCRIPTION
Since tile-generator has deprecated using hyphens in names and Kubernetes requires a DNS compliant name (without underscores), convert underscores to hyphens for the service name.