### PR TITLE
Add possibility to configure Plan "bindable" and "free" params

### DIFF
--- a/docs/example-chart/plans.yaml
+++ b/docs/example-chart/plans.yaml
@@ -1,6 +1,14 @@
-- name: "default"
+- name: "default-free"
   description: "default plan for spacebears"
   bullets:  #Optional. If not provided, one Bullet with value of field description will be used.
   - bullet1 for plan for spacebears
   - bullet2 for plan for spacebears
   file: "default.yaml"
+- name: "default-paid-undbindable"
+  description: "default plan for spacebears"
+  bullets:  #Optional. If not provided, one Bullet with value of field description will be used.
+  - bullet1 for plan for spacebears
+  - bullet2 for plan for spacebears
+  file: "default.yaml"
+  free: false #optional, defaults to true
+  bindable: false #optional, defaults to true

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -83,7 +83,6 @@ func (broker *PksServiceBroker) Services(ctx context.Context) ([]brokerapi.Servi
 	for _, chart := range broker.GetChartsMap() {
 		plans := []brokerapi.ServicePlan{}
 		for _, plan := range chart.Plans {
-
 			plans = append(plans, brokerapi.ServicePlan{
 				ID:          broker.getServiceID(chart) + "-" + plan.Name,
 				Name:        plan.Name,
@@ -99,6 +98,8 @@ func (broker *PksServiceBroker) Services(ctx context.Context) ([]brokerapi.Servi
 						return plan.Bullets
 					}(),
 				},
+				Bindable: brokerapi.BindableValue(*plan.Bindable),
+				Free:     brokerapi.FreeValue(*plan.Free),
 			})
 		}
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -75,12 +75,16 @@ var _ = Describe("Broker", func() {
 					Name:        "small",
 					Description: "default (small) plan for spacebears",
 					File:        "small.yaml",
+					Free:        brokerapi.FreeValue(true),
+					Bindable:    brokerapi.BindableValue(true),
 				},
 				"medium": {
 					Name:        "medium",
 					Description: "medium plan for spacebears",
 					File:        "medium.yaml",
 					Bullets:     bullets,
+					Free:        brokerapi.FreeValue(false),
+					Bindable:    brokerapi.BindableValue(true),
 				},
 			},
 		}
@@ -96,11 +100,15 @@ var _ = Describe("Broker", func() {
 					Name:        "tiny",
 					Description: "tiny data",
 					File:        "tiny.yaml",
+					Free:        brokerapi.FreeValue(true),
+					Bindable:    brokerapi.BindableValue(true),
 				},
 				"medium": {
 					Name:        "big",
 					Description: "big data",
 					File:        "big.yaml",
+					Free:        brokerapi.FreeValue(false),
+					Bindable:    brokerapi.BindableValue(false),
 				},
 			},
 		}
@@ -153,6 +161,8 @@ var _ = Describe("Broker", func() {
 							"default (small) plan for spacebears",
 						},
 					},
+					Free:     brokerapi.FreeValue(true),
+					Bindable: brokerapi.BindableValue(true),
 				},
 				{
 					ID:          "37b7acb6-6755-56fe-a17f-2307657023ef-medium",
@@ -165,6 +175,8 @@ var _ = Describe("Broker", func() {
 							"bullet2 for plan for spacebears",
 						},
 					},
+					Free:     brokerapi.FreeValue(false),
+					Bindable: brokerapi.BindableValue(true),
 				},
 			}
 

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -41,10 +41,12 @@ type MyChart struct {
 }
 
 type Plan struct {
-	Name        string `yaml:"name"`
-	Description string `yaml:"description"`
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
 	Bullets     []string `yaml:"bullets"`
-	File        string `yaml:"file"`
+	File        string   `yaml:"file"`
+	Free        *bool    `yaml:"free,omitempty"`
+	Bindable    *bool    `yaml:"bindable,omitempty"`
 	Values      []byte
 }
 
@@ -156,6 +158,8 @@ func (c *MyChart) OverrideImageSources(rawVals map[string]interface{}) (map[stri
 }
 
 func (c *MyChart) loadPlans() error {
+	T := true
+
 	plansPath := path.Join(c.Chartpath, "plans.yaml")
 	bytes, err := ioutil.ReadFile(plansPath)
 	if err != nil {
@@ -170,7 +174,12 @@ func (c *MyChart) loadPlans() error {
 
 	c.Plans = map[string]Plan{}
 	for _, p := range plans {
-
+		if p.Free == nil {
+			p.Free = &T
+		}
+		if p.Bindable == nil {
+			p.Bindable = &T
+		}
 		match, err := regexp.MatchString(`^[0-9a-z.\-]+$`, p.Name)
 		if err != nil {
 			return err


### PR DESCRIPTION
Hi there, 

I added optional config for "bindable" & "free" plan params. Defaults to true… Initializing of default values via pointers similar to https://godoc.org/github.com/pivotal-cf/brokerapi#ServicePlan. Added Tests for Plan.Bindable & Plan.Free.