### PR TITLE
Upgrade brokerapi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ charts.bk
 operators
 operators.bk
 local_dev.sh
+manifest.yml

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -532,15 +532,15 @@
   version = "v2.0.1"
 
 [[projects]]
-  digest = "1:48668938fc4e101dec495aa6f80edfbb4961e125096c5db2d3082361c681a2ed"
+  digest = "1:895e30fce615ada85a8c1d74a1b1aed1cddccbd9615706f349e463692db041e9"
   name = "github.com/pivotal-cf/brokerapi"
   packages = [
     ".",
     "auth",
   ]
   pruneopts = "U"
-  revision = "d1fcddd951a6776bc01659143dda6aca057e98b7"
-  version = "v2.0.4"
+  revision = "4048f6de26b2169b7bc3063076b47964d02045eb"
+  version = "v3.0.7"
 
 [[projects]]
   digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,12 +3,12 @@
 
 required = [
     "github.com/go-openapi/spec",
-    "github.com/emicklei/go-restful"
+    "github.com/emicklei/go-restful",
 ]
 
 ignored = [
     "github.com/onsi/ginkgo",
-    "github.com/onsi/gomega"
+    "github.com/onsi/gomega",
 ]
 
 [prune]
@@ -72,7 +72,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/pivotal-cf/brokerapi"
-  version = "~v2.0.0"
+  version = "v3.0.2"
 
 [[override]]
   name = "code.cloudfoundry.org/lager"
@@ -89,7 +89,3 @@ ignored = [
 [[constraint]]
   name = "github.com/dgraph-io/badger"
   version = "1.5.3"
-
-[[constraint]]
-  name = "github.com/golang/protobuf"
-  version = "1.2.0"

--- a/pkg/k8s/cluster.go
+++ b/pkg/k8s/cluster.go
@@ -100,7 +100,6 @@ func NewClusterFromDefaultConfig() (Cluster, error) {
 }
 
 func GetClusterFromK8sConfig(k8sConfig *k8sAPI.Config) (Cluster, error) {
-
 	if k8sConfig.CurrentContext == "" {
 		return nil, errors.New("the default Kubernetes config has no current context")
 	}
@@ -119,7 +118,6 @@ func GetClusterFromK8sConfig(k8sConfig *k8sAPI.Config) (Cluster, error) {
 	}
 
 	return NewCluster(creds)
-
 }
 
 func (cluster *cluster) GetClientConfig() *rest.Config {

--- a/pkg/k8s/cluster_factory.go
+++ b/pkg/k8s/cluster_factory.go
@@ -17,12 +17,14 @@ package k8s
 
 import (
 	"github.com/cf-platform-eng/kibosh/pkg/config"
+	k8sAPI "k8s.io/client-go/tools/clientcmd/api"
 )
 
 //go:generate counterfeiter ./ ClusterFactory
 type ClusterFactory interface {
 	DefaultCluster() (Cluster, error)
 	GetCluster(creds *config.ClusterCredentials) (Cluster, error)
+	GetClusterFromK8sConfig(k8sConfig *k8sAPI.Config) (Cluster, error)
 }
 
 func NewClusterFactory(clusterCredentials config.ClusterCredentials) ClusterFactory {
@@ -39,4 +41,8 @@ func (cf clusterFactory) DefaultCluster() (Cluster, error) {
 
 func (cf clusterFactory) GetCluster(creds *config.ClusterCredentials) (Cluster, error) {
 	return NewCluster(creds)
+}
+
+func (cf clusterFactory) GetClusterFromK8sConfig(k8sConfig *k8sAPI.Config) (Cluster, error) {
+	return GetClusterFromK8sConfig(k8sConfig)
 }

--- a/pkg/k8s/k8sfakes/fake_cluster_factory.go
+++ b/pkg/k8s/k8sfakes/fake_cluster_factory.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cf-platform-eng/kibosh/pkg/config"
 	"github.com/cf-platform-eng/kibosh/pkg/k8s"
+	k8sAPI "k8s.io/client-go/tools/clientcmd/api"
 )
 
 type FakeClusterFactory struct {
@@ -30,6 +31,19 @@ type FakeClusterFactory struct {
 		result2 error
 	}
 	getClusterReturnsOnCall map[int]struct {
+		result1 k8s.Cluster
+		result2 error
+	}
+	GetClusterFromK8sConfigStub        func(k8sConfig *k8sAPI.Config) (k8s.Cluster, error)
+	getClusterFromK8sConfigMutex       sync.RWMutex
+	getClusterFromK8sConfigArgsForCall []struct {
+		k8sConfig *k8sAPI.Config
+	}
+	getClusterFromK8sConfigReturns struct {
+		result1 k8s.Cluster
+		result2 error
+	}
+	getClusterFromK8sConfigReturnsOnCall map[int]struct {
 		result1 k8s.Cluster
 		result2 error
 	}
@@ -131,6 +145,57 @@ func (fake *FakeClusterFactory) GetClusterReturnsOnCall(i int, result1 k8s.Clust
 	}{result1, result2}
 }
 
+func (fake *FakeClusterFactory) GetClusterFromK8sConfig(k8sConfig *k8sAPI.Config) (k8s.Cluster, error) {
+	fake.getClusterFromK8sConfigMutex.Lock()
+	ret, specificReturn := fake.getClusterFromK8sConfigReturnsOnCall[len(fake.getClusterFromK8sConfigArgsForCall)]
+	fake.getClusterFromK8sConfigArgsForCall = append(fake.getClusterFromK8sConfigArgsForCall, struct {
+		k8sConfig *k8sAPI.Config
+	}{k8sConfig})
+	fake.recordInvocation("GetClusterFromK8sConfig", []interface{}{k8sConfig})
+	fake.getClusterFromK8sConfigMutex.Unlock()
+	if fake.GetClusterFromK8sConfigStub != nil {
+		return fake.GetClusterFromK8sConfigStub(k8sConfig)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.getClusterFromK8sConfigReturns.result1, fake.getClusterFromK8sConfigReturns.result2
+}
+
+func (fake *FakeClusterFactory) GetClusterFromK8sConfigCallCount() int {
+	fake.getClusterFromK8sConfigMutex.RLock()
+	defer fake.getClusterFromK8sConfigMutex.RUnlock()
+	return len(fake.getClusterFromK8sConfigArgsForCall)
+}
+
+func (fake *FakeClusterFactory) GetClusterFromK8sConfigArgsForCall(i int) *k8sAPI.Config {
+	fake.getClusterFromK8sConfigMutex.RLock()
+	defer fake.getClusterFromK8sConfigMutex.RUnlock()
+	return fake.getClusterFromK8sConfigArgsForCall[i].k8sConfig
+}
+
+func (fake *FakeClusterFactory) GetClusterFromK8sConfigReturns(result1 k8s.Cluster, result2 error) {
+	fake.GetClusterFromK8sConfigStub = nil
+	fake.getClusterFromK8sConfigReturns = struct {
+		result1 k8s.Cluster
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClusterFactory) GetClusterFromK8sConfigReturnsOnCall(i int, result1 k8s.Cluster, result2 error) {
+	fake.GetClusterFromK8sConfigStub = nil
+	if fake.getClusterFromK8sConfigReturnsOnCall == nil {
+		fake.getClusterFromK8sConfigReturnsOnCall = make(map[int]struct {
+			result1 k8s.Cluster
+			result2 error
+		})
+	}
+	fake.getClusterFromK8sConfigReturnsOnCall[i] = struct {
+		result1 k8s.Cluster
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClusterFactory) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -138,6 +203,8 @@ func (fake *FakeClusterFactory) Invocations() map[string][][]interface{} {
 	defer fake.defaultClusterMutex.RUnlock()
 	fake.getClusterMutex.RLock()
 	defer fake.getClusterMutex.RUnlock()
+	fake.getClusterFromK8sConfigMutex.RLock()
+	defer fake.getClusterFromK8sConfigMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
Increment the brokerapi version to `3.0.2` (and thus also support OSBAPI 2.14.

Also wire cluster-per-plan in the remainder of the OSBAPI calls (sorry this wasn't separate PR).

Co-authored-by: Jeenal Shah <jshah@pivotal.io>