### PR TITLE
Make Deletion Actually Async

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -85,7 +85,3 @@ ignored = [
 [[constraint]]
   branch = "master"
   name = "github.com/cloudfoundry-community/go-cfclient"
-
-[[constraint]]
-  name = "github.com/dgraph-io/badger"
-  version = "1.5.3"

--- a/docs/test_harness.py
+++ b/docs/test_harness.py
@@ -1,0 +1,111 @@
+import json
+import requests.auth
+import sys
+
+host = "http://localhost:8090"
+username = "admin"
+password = "monkey123"
+
+instance_id = "tuesday3"
+service_id = "c76ed0a4-9a04-5710-90c2-75e955697b08"
+plan_id = service_id + "-small"
+
+auth = requests.auth.HTTPBasicAuth(username, password)
+headers = {
+    "X-Broker-API-Version": "2.14",
+}
+
+
+def catalog():
+    url = host + "/v2/catalog"
+    try:
+        print("Requesting url [{}]".format(url))
+        r = requests.get(url, auth=auth, headers=headers)
+        print("Status {}".format(r.status_code))
+        if r.status_code < 400:
+            json_body = json.loads(r.content.decode())
+            print("Response\n", json.dumps(json_body, indent=2))
+    except requests.ConnectionError as e:
+        print(e, sys.stderr)
+        sys.exit(1)
+
+
+def provision():
+    url = host + "/v2/service_instances/{}?accepts_incomplete=true".format(instance_id)
+    try:
+        print("Requesting url [{}]".format(url))
+        r = requests.put(url, auth=auth, headers=headers, data=json.dumps({
+            "service_id": service_id,
+            "plan_id": plan_id,
+        }))
+        print("Status {}".format(r.status_code))
+        if r.status_code < 400:
+            json_body = json.loads(r.content.decode())
+            print("Response\n", json.dumps(json_body, indent=2))
+    except requests.ConnectionError as e:
+        print(e, sys.stderr)
+        sys.exit(1)
+
+
+def provision_status():
+    url = host + "/v2/service_instances/{}/last_operation?operation=provision&service_id={}&plan_id={}".format(
+        instance_id, service_id, plan_id
+    )
+    try:
+        print("Requesting url [{}]".format(url))
+        r = requests.get(url, auth=auth, headers=headers, data=json.dumps({
+            "service_id": service_id,
+            "plan_id": plan_id,
+        }))
+        print("Status {}".format(r.status_code))
+        if r.status_code < 400:
+            json_body = json.loads(r.content.decode())
+            print("Response\n", json.dumps(json_body, indent=2))
+    except requests.ConnectionError as e:
+        print(e, sys.stderr)
+        sys.exit(1)
+
+
+def de_provision():
+    url = host + "/v2/service_instances/{}?service_id={}&plan_id={}".format(
+        instance_id, service_id, plan_id
+    )
+    try:
+        print("Requesting url {}".format(url))
+        r = requests.delete(url, auth=auth, headers=headers, data=json.dumps({
+            "service_id": service_id,
+            "plan_id": plan_id,
+        }))
+        print("Status {}".format(r.status_code))
+        if r.status_code < 400:
+            json_body = json.loads(r.content.decode())
+            print("Response\n", json.dumps(json_body, indent=2))
+    except requests.ConnectionError as e:
+        print(e, sys.stderr)
+        sys.exit(1)
+
+
+def de_provision_status():
+    url = host + "/v2/service_instances/{}/last_operation?operation=deprovision&service_id={}&plan_id={}".format(
+        instance_id, service_id, plan_id
+    )
+    try:
+        print("Requesting url {}".format(url))
+        r = requests.get(url, auth=auth, headers=headers, data=json.dumps({
+            "service_id": service_id,
+            "plan_id": plan_id,
+        }))
+        print("Status {}".format(r.status_code))
+        if r.status_code < 400:
+            json_body = json.loads(r.content.decode())
+            print("Response\n", json.dumps(json_body, indent=2))
+    except requests.ConnectionError as e:
+        print(e, sys.stderr)
+        sys.exit(1)
+
+
+#catalog()
+#provision()
+# provision_status()
+# de_provision()
+de_provision_status()

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -18,14 +18,12 @@ package broker_test
 import (
 	"encoding/json"
 	"errors"
-	"github.com/cf-platform-eng/kibosh/pkg/k8s"
-	"strings"
-
 	"github.com/Sirupsen/logrus"
 	. "github.com/cf-platform-eng/kibosh/pkg/broker"
 	my_config "github.com/cf-platform-eng/kibosh/pkg/config"
 	my_helm "github.com/cf-platform-eng/kibosh/pkg/helm"
 	"github.com/cf-platform-eng/kibosh/pkg/helm/helmfakes"
+	"github.com/cf-platform-eng/kibosh/pkg/k8s"
 	"github.com/cf-platform-eng/kibosh/pkg/k8s/k8sfakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -36,6 +34,7 @@ import (
 	hapi_chart "k8s.io/helm/pkg/proto/hapi/chart"
 	hapi_release "k8s.io/helm/pkg/proto/hapi/release"
 	hapi_services "k8s.io/helm/pkg/proto/hapi/services"
+	"strings"
 )
 
 var _ = Describe("Broker", func() {
@@ -1003,52 +1002,39 @@ var _ = Describe("Broker", func() {
 			broker = NewPksServiceBroker(config, &fakeClusterFactory, &fakeHelmClientFactory, &fakeServiceAccountInstallerFactory, fakeInstallerFactory, charts, nil, logger)
 		})
 
-		It("bubbles up delete chart errors", func() {
-			fakeHelmClient.DeleteReleaseReturns(nil, errors.New("Failed"))
-
-			details := brokerapi.DeprovisionDetails{
-				PlanID:    "my-plan-id",
-				ServiceID: "my-service-id",
-			}
-			_, err := broker.Deprovision(nil, "my-instance-guid", details, true)
-
-			Expect(err).NotTo(BeNil())
-			Expect(fakeHelmClient.DeleteReleaseCallCount()).To(Equal(1))
-
-		})
-
-		It("bubbles up delete namespace errors", func() {
-			fakeCluster.DeleteNamespaceReturns(errors.New("nope"))
-
-			details := brokerapi.DeprovisionDetails{
-				PlanID:    "my-plan-id",
-				ServiceID: "my-service-id",
-			}
-			_, err := broker.Deprovision(nil, "my-instance-guid", details, true)
-
-			Expect(err).NotTo(BeNil())
-			Expect(fakeCluster.DeleteNamespaceCallCount()).To(Equal(1))
-
-		})
-
 		It("correctly calls deletion", func() {
 			details := brokerapi.DeprovisionDetails{
 				PlanID:    "my-plan-id",
 				ServiceID: "my-service-id",
 			}
 			response, err := broker.Deprovision(nil, "my-instance-guid", details, true)
-
-			namespace, _ := fakeCluster.DeleteNamespaceArgsForCall(0)
-			Expect(namespace).To(Equal("kibosh-my-instance-guid"))
-
-			releaseName, _ := fakeHelmClient.DeleteReleaseArgsForCall(0)
-			Expect(releaseName).To(Equal("kibosh-my-instance-guid"))
-
 			Expect(err).To(BeNil())
 			Expect(response.IsAsync).To(BeTrue())
 			Expect(response.OperationData).To(Equal("deprovision"))
-			Expect(fakeClusterFactory.DefaultClusterCallCount()).ShouldNot(Equal(0))
-			Expect(fakeClusterFactory.GetClusterCallCount()).To(Equal(0))
+
+			Eventually(func() int {
+				return fakeCluster.DeleteNamespaceCallCount()
+			}).Should(Equal(1))
+			Eventually(func() string {
+				namespace, _ := fakeCluster.DeleteNamespaceArgsForCall(0)
+				return namespace
+			}).Should(Equal("kibosh-my-instance-guid"))
+
+			Eventually(func() int {
+				return fakeHelmClient.DeleteReleaseCallCount()
+			}).Should(Equal(1))
+			Eventually(func() string {
+				releaseName, _ := fakeHelmClient.DeleteReleaseArgsForCall(0)
+				return releaseName
+			}).Should(Equal("kibosh-my-instance-guid"))
+
+			Consistently(func() int {
+				return fakeClusterFactory.GetClusterCallCount()
+			}).Should(Equal(0))
+
+			Eventually(func() int {
+				return fakeClusterFactory.DefaultClusterCallCount()
+			}).Should(Equal(1))
 		})
 
 		It("targets the plan specific cluster", func() {


### PR DESCRIPTION
Potentially, the namespace and chart deletion can exceed the 60 second response window. Make it actually async (it was just pretending before).

Co-authored-by: Jeenal Shah <jshah@pivotal.io>