### PR TITLE
Default plan

### DIFF
--- a/cmd/bazaarapi/main.go
+++ b/cmd/bazaarapi/main.go
@@ -34,7 +34,7 @@ func main() {
 		bazaarLogger.Fatal("Loading config file", err)
 	}
 
-	repo := repository.NewRepository(conf.HelmChartDir, conf.RegistryConfig.Server, true, bazaarLogger)
+	repo := repository.NewRepository(conf.HelmChartDir, conf.RegistryConfig.Server, bazaarLogger)
 	bazaarAPI := bazaar.NewAPI(repo, conf.KiboshConfig, bazaarLogger)
 	authFilter := httphelpers.NewAuthFilter(conf.AdminUsername, conf.AdminPassword)
 

--- a/cmd/kibosh/main.go
+++ b/cmd/kibosh/main.go
@@ -41,7 +41,7 @@ func main() {
 		kiboshLogger.Fatal("Loading config file", err)
 	}
 
-	repo := repository.NewRepository(conf.HelmChartDir, conf.RegistryConfig.Server, true, kiboshLogger)
+	repo := repository.NewRepository(conf.HelmChartDir, conf.RegistryConfig.Server, kiboshLogger)
 	charts, err := repo.LoadCharts()
 	if err != nil {
 		kiboshLogger.Fatal("Unable to load charts", err)
@@ -61,7 +61,7 @@ func main() {
 		}
 	}
 
-	operatorRepo := repository.NewRepository(conf.OperatorDir, conf.RegistryConfig.Server, false, kiboshLogger)
+	operatorRepo := repository.NewRepository(conf.OperatorDir, conf.RegistryConfig.Server, kiboshLogger)
 	operatorCharts, err := operatorRepo.LoadCharts()
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -55,10 +55,6 @@ type ChartValidationError struct {
 	error
 }
 
-type NoPlansError struct {
-	error
-}
-
 type Plan struct {
 	Name            string   `yaml:"name"`
 	Description     string   `yaml:"description"`
@@ -88,7 +84,7 @@ func LoadFromDir(dir string, log *logrus.Logger, requirePlans bool) ([]*MyChart,
 	charts := []*MyChart{}
 	for _, source := range sources {
 		chartPath := path.Join(dir, source.Name())
-		c, err := NewChart(chartPath, "", requirePlans)
+		c, err := NewChart(chartPath, "")
 		if err != nil {
 			log.Debug(fmt.Sprintf("The file [%s] not failed to load as a chart", chartPath), err)
 		} else {
@@ -99,7 +95,7 @@ func LoadFromDir(dir string, log *logrus.Logger, requirePlans bool) ([]*MyChart,
 	return charts, nil
 }
 
-func NewChart(chartPath string, privateRegistryServer string, requirePlans bool) (*MyChart, error) {
+func NewChart(chartPath string, privateRegistryServer string) (*MyChart, error) {
 	myChart := &MyChart{
 		Chartpath:             chartPath,
 		privateRegistryServer: privateRegistryServer,
@@ -128,24 +124,23 @@ func NewChart(chartPath string, privateRegistryServer string, requirePlans bool)
 		return nil, NewChartValidationError(err)
 	}
 
-	if requirePlans {
-		if chartPathStat.IsDir() {
-			err = myChart.loadPlansFromDirectory()
-		} else {
-			err = myChart.loadPlansFromArchive()
+	if chartPathStat.IsDir() {
+		err = myChart.loadPlansFromDirectory()
+	} else {
+		err = myChart.loadPlansFromArchive()
+	}
+
+	if err != nil {
+		return nil, NewChartValidationError(err)
+	}
+	if len(myChart.Plans) < 1 {
+		defaultPlan := Plan{
+			Name:        "default",
+			Description: "Plan with default values",
 		}
-
-		if err != nil {
-
-			_, ok := err.(*NoPlansError)
-			if ok {
-				myChart.Plans["default"] = Plan{
-					Name: "default",
-				}
-			} else {
-				return nil, NewChartValidationError(err)
-			}
-
+		myChart.SetPlanDefaultValues(&defaultPlan)
+		myChart.Plans = map[string]Plan{
+			"default": defaultPlan,
 		}
 	}
 
@@ -289,11 +284,9 @@ func (c *MyChart) loadPlansFromDirectory() error {
 	_, err := os.Stat(plansPath)
 	if err != nil {
 		_, ok := err.(*os.PathError)
-
 		if ok {
-			return &NoPlansError{
-				error: err,
-			}
+			c.Plans = map[string]Plan{}
+			return nil
 		} else {
 			return err
 		}
@@ -323,14 +316,7 @@ func (c *MyChart) loadPlans(plansPath string, plans []Plan) error {
 		}
 		p.Values = planValues
 
-		if p.Free == nil {
-			t := true
-			p.Free = &t
-		}
-		if p.Bindable == nil {
-			t := true
-			p.Bindable = &t
-		}
+		c.SetPlanDefaultValues(&p)
 		match, err := regexp.MatchString(`^[0-9a-z.\-]+$`, p.Name)
 		if err != nil {
 			return err
@@ -355,6 +341,17 @@ func (c *MyChart) loadPlans(plansPath string, plans []Plan) error {
 	}
 
 	return nil
+}
+
+func (c *MyChart) SetPlanDefaultValues(plan *Plan) {
+	if plan.Free == nil {
+		t := true
+		plan.Free = &t
+	}
+	if plan.Bindable == nil {
+		t := true
+		plan.Bindable = &t
+	}
 }
 
 func (c *MyChart) EnsureIgnore() error {

--- a/pkg/helm/chart_test.go
+++ b/pkg/helm/chart_test.go
@@ -177,6 +177,19 @@ var _ = Describe("Broker", func() {
 			Expect(charts[0].Metadata.Name).To(Equal("spacebears"))
 			Expect(charts[1].Metadata.Name).To(Equal("spacebears2"))
 		})
+
+	})
+
+	FIt("plans.yaml doesn't exist", func() {
+
+		err := os.Remove(filepath.Join(chartPath, "plans.yaml"))
+		Expect(err).To(BeNil())
+		charts, err := helm.LoadFromDir(chartPath, logrus.New(), true)
+		Expect(err).To(BeNil())
+		Expect(charts).To(HaveLen(1))
+		Expect(charts[0].Plans).To(HaveLen(1))
+		_, ok := charts[0].Plans["default"]
+		Expect(ok).To(BeTrue())
 	})
 
 	It("should return error when no vals file", func() {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -38,15 +38,13 @@ type Repository interface {
 type repository struct {
 	helmChartDir          string
 	privateRegistryServer string
-	expectOSBAPICharts    bool
 	logger                *logrus.Logger
 }
 
-func NewRepository(chartPath string, privateRegistryServer string, expectOSBAPICharts bool, logger *logrus.Logger) Repository {
+func NewRepository(chartPath string, privateRegistryServer string, logger *logrus.Logger) Repository {
 	return &repository{
 		helmChartDir:          chartPath,
 		privateRegistryServer: privateRegistryServer,
-		expectOSBAPICharts:    expectOSBAPICharts,
 		logger:                logger,
 	}
 }
@@ -60,7 +58,7 @@ func (r *repository) LoadCharts() ([]*helm.MyChart, error) {
 	}
 
 	if chartExists {
-		myChart, err := helm.NewChart(r.helmChartDir, r.privateRegistryServer, r.expectOSBAPICharts)
+		myChart, err := helm.NewChart(r.helmChartDir, r.privateRegistryServer)
 		if err != nil {
 			return charts, err
 		}
@@ -82,7 +80,7 @@ func (r *repository) LoadCharts() ([]*helm.MyChart, error) {
 					return charts, err
 				}
 				if subdirChartExists {
-					myChart, err := helm.NewChart(filepath.Join(subChartPath), r.privateRegistryServer, r.expectOSBAPICharts)
+					myChart, err := helm.NewChart(filepath.Join(subChartPath), r.privateRegistryServer)
 					if err != nil {
 						return charts, err
 					}
@@ -131,7 +129,7 @@ func (r *repository) SaveChart(path string) error {
 	}
 
 	chartPath := filepath.Join(expandedTarPath, chartPathInfo.Name())
-	chart, err := helm.NewChart(chartPath, r.privateRegistryServer, r.expectOSBAPICharts)
+	chart, err := helm.NewChart(chartPath, r.privateRegistryServer)
 	if err != nil {
 		return err
 	}

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -59,20 +59,20 @@ var _ = Describe("Repository", func() {
 		})
 
 		It("returns error on empty path", func() {
-			myRepository := repository.NewRepository("", "", true, logger)
+			myRepository := repository.NewRepository("", "", logger)
 			_, err := myRepository.LoadCharts()
 			Expect(err).NotTo(BeNil())
 		})
 
 		It("returns empty slice on directory with no charts", func() {
-			myRepository := repository.NewRepository(emptyDir, "", true, logger)
+			myRepository := repository.NewRepository(emptyDir, "", logger)
 			charts, err := myRepository.LoadCharts()
 			Expect(charts).To(BeEmpty())
 			Expect(err).To(BeNil())
 		})
 
 		It("returns empty slice on directory with empty directories", func() {
-			myRepository := repository.NewRepository(nestedEmptyDir, "", true, logger)
+			myRepository := repository.NewRepository(nestedEmptyDir, "", logger)
 			charts, err := myRepository.LoadCharts()
 			Expect(charts).To(BeEmpty())
 			Expect(err).To(BeNil())
@@ -97,7 +97,7 @@ var _ = Describe("Repository", func() {
 		})
 
 		It("returns single chart", func() {
-			myRepository := repository.NewRepository(chartPath, "", true, logger)
+			myRepository := repository.NewRepository(chartPath, "", logger)
 			charts, err := myRepository.LoadCharts()
 			Expect(err).To(BeNil())
 
@@ -123,14 +123,8 @@ var _ = Describe("Repository", func() {
 			os.RemoveAll(chartPath)
 		})
 
-		It("returns err when expecting an osbapi chart", func() {
-			myRepository := repository.NewRepository(chartPath, "", true, logger)
-			_, err := myRepository.LoadCharts()
-			Expect(err).ToNot(BeNil())
-		})
-
 		It("returns a single plain chart", func() {
-			myRepository := repository.NewRepository(chartPath, "", false, logger)
+			myRepository := repository.NewRepository(chartPath, "", logger)
 			charts, err := myRepository.LoadCharts()
 			Expect(err).To(BeNil())
 
@@ -181,7 +175,7 @@ version: 0.0.1
 
 		It("loads multiple charts", func() {
 			logger = logrus.New()
-			myRepository := repository.NewRepository(chartPath, "", true, logger)
+			myRepository := repository.NewRepository(chartPath, "", logger)
 
 			charts, err := myRepository.LoadCharts()
 			Expect(err).To(BeNil())
@@ -196,7 +190,7 @@ version: 0.0.1
 			Expect(err).To(BeNil())
 
 			logger = logrus.New()
-			myRepository := repository.NewRepository(chartPath, "", true, logger)
+			myRepository := repository.NewRepository(chartPath, "", logger)
 
 			_, err = myRepository.LoadCharts()
 			Expect(err).NotTo(BeNil())
@@ -227,10 +221,10 @@ version: 0.0.1
 			err := testChart.WriteChart(tarDir)
 			Expect(err).To(BeNil())
 
-			chart, err := helm.NewChart(tarDir, "docker.example.com", true)
+			chart, err := helm.NewChart(tarDir, "docker.example.com")
 			tarFile, err := chartutil.Save(chart.Chart, tarDir)
 
-			myRepository := repository.NewRepository(repoDir, "", true, logger)
+			myRepository := repository.NewRepository(repoDir, "", logger)
 			files, err := ioutil.ReadDir(repoDir)
 			Expect(err).To(BeNil())
 			Expect(files).To(HaveLen(0))
@@ -258,7 +252,7 @@ version: 0.0.1
 			err := ioutil.WriteFile(notChartFilePath, []byte("foo"), 0666)
 			Expect(err).To(BeNil())
 
-			myRepository := repository.NewRepository(repoDir, "", true, logger)
+			myRepository := repository.NewRepository(repoDir, "", logger)
 
 			err = myRepository.SaveChart(notChartFilePath)
 			Expect(err).NotTo(BeNil())
@@ -276,10 +270,10 @@ version: 0.0.1
 			err = testChart.WriteChart(tarDir)
 			Expect(err).To(BeNil())
 
-			chart, err := helm.NewChart(tarDir, "docker.example.com", true)
+			chart, err := helm.NewChart(tarDir, "docker.example.com")
 			tarFile, err := chartutil.Save(chart.Chart, tarDir)
 
-			myRepository := repository.NewRepository(repoDir, "", true, logger)
+			myRepository := repository.NewRepository(repoDir, "", logger)
 			_, err = ioutil.ReadDir(repoDir)
 			Expect(err).To(BeNil())
 
@@ -294,10 +288,10 @@ version: 0.0.1
 			err := testChart.WriteChart(tarDir)
 			Expect(err).To(BeNil())
 
-			chart, err := helm.NewChart(tarDir, "docker.example.com", true)
+			chart, err := helm.NewChart(tarDir, "docker.example.com")
 			tarFile, err := chartutil.Save(chart.Chart, tarDir)
 
-			myRepository := repository.NewRepository(repoDir, "", true, logger)
+			myRepository := repository.NewRepository(repoDir, "", logger)
 			files, err := ioutil.ReadDir(repoDir)
 			Expect(err).To(BeNil())
 			Expect(files).To(HaveLen(0))
@@ -317,7 +311,7 @@ version: 0.0.2
 
 			err = testChart2.WriteChart(tarDir2)
 			Expect(err).To(BeNil())
-			chart2, err := helm.NewChart(tarDir2, "docker.example.com", true)
+			chart2, err := helm.NewChart(tarDir2, "docker.example.com")
 			Expect(err).To(BeNil())
 
 			tarFile2, err := chartutil.Save(chart2.Chart, tarDir2)
@@ -352,7 +346,7 @@ version: 0.0.2
 			err = testChart.WriteChart(deletePath)
 			Expect(err).To(BeNil())
 			logger = logrus.New()
-			myRepository := repository.NewRepository(chartPath, "", true, logger)
+			myRepository := repository.NewRepository(chartPath, "", logger)
 
 			err = myRepository.DeleteChart("spacebears")
 			Expect(err).To(BeNil())
@@ -378,7 +372,7 @@ version: 0.0.2
 			Expect(err).To(BeNil())
 
 			logger = logrus.New()
-			myRepository := repository.NewRepository(chartPath, "", true, logger)
+			myRepository := repository.NewRepository(chartPath, "", logger)
 
 			err = myRepository.DeleteChart("spacebears")
 			Expect(err).To(BeNil())
@@ -396,7 +390,7 @@ version: 0.0.2
 			Expect(err).To(BeNil())
 
 			logger = logrus.New()
-			myRepository := repository.NewRepository(chartPath, "", true, logger)
+			myRepository := repository.NewRepository(chartPath, "", logger)
 
 			err = myRepository.DeleteChart("spacebears")
 			Expect(err).To(BeNil())


### PR DESCRIPTION
No longer require `plans.yaml` in a chart. When this file isn't present, simply create a `default` option that doesn't override any values.