### PR TITLE
Use the k8s context's username & password to connect to the cluster

### DIFF
--- a/cmd/templatetester/main.go
+++ b/cmd/templatetester/main.go
@@ -6,9 +6,10 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/ghodss/yaml"
+
 	"github.com/cf-platform-eng/kibosh/pkg/helm"
 	"github.com/cf-platform-eng/kibosh/pkg/k8s"
-	"github.com/ghodss/yaml"
 )
 
 func main() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,8 +16,9 @@
 package config
 
 import (
-	"github.com/cf-platform-eng/kibosh/pkg/moreio"
 	"github.com/kelseyhightower/envconfig"
+
+	"github.com/cf-platform-eng/kibosh/pkg/moreio"
 
 	"encoding/base64"
 	"encoding/json"
@@ -31,6 +32,8 @@ type ClusterCredentials struct {
 	CAData    []byte
 	Server    string `envconfig:"SERVER" json:"server"`
 	Token     string `envconfig:"TOKEN" json:"token"`
+	Username  string `envconfig:"USERNAME" json:"username"`
+	Password  string `envconfig:"PASSWORD" json:"password"`
 }
 
 type RegistryConfig struct {

--- a/pkg/k8s/cluster.go
+++ b/pkg/k8s/cluster.go
@@ -16,7 +16,6 @@
 package k8s
 
 import (
-	"github.com/cf-platform-eng/kibosh/pkg/config"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	api_v1 "k8s.io/api/core/v1"
@@ -32,6 +31,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	k8sAPI "k8s.io/client-go/tools/clientcmd/api"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
+
+	"github.com/cf-platform-eng/kibosh/pkg/config"
 )
 
 //go:generate counterfeiter ./ Cluster
@@ -148,14 +149,18 @@ func GetClusterFromK8sConfig(k8sConfig *k8sAPI.Config) (Cluster, error) {
 	context := k8sConfig.Contexts[k8sConfig.CurrentContext]
 	authInfo := k8sConfig.AuthInfos[context.AuthInfo]
 	token := authInfo.Token
+	username := authInfo.Username
+	password := authInfo.Password
 	server := k8sConfig.Clusters[context.Cluster].Server
 	cert := k8sConfig.Clusters[context.Cluster].CertificateAuthorityData
 
 	var creds *config.ClusterCredentials
 	creds = &config.ClusterCredentials{
-		CAData: cert,
-		Server: server,
-		Token:  token,
+		CAData:   cert,
+		Server:   server,
+		Token:    token,
+		Username: username,
+		Password: password,
 	}
 
 	return NewCluster(creds)
@@ -306,6 +311,8 @@ func buildClientConfig(credentials *config.ClusterCredentials) (*rest.Config, er
 		Host:            credentials.Server,
 		BearerToken:     credentials.Token,
 		TLSClientConfig: tlsClientConfig,
+		Username:        credentials.Username,
+		Password:        credentials.Password,
 	}, nil
 }
 


### PR DESCRIPTION
We've had issues using the template-tester on some of our clusters. Pass the kube context username & password along to connect to the cluster.